### PR TITLE
Fix date of the decklist

### DIFF
--- a/YGOProAnalyticsServer/EventHandlers/YgoProAnalysisBasedOnDataFromYgoProServer.cs
+++ b/YGOProAnalyticsServer/EventHandlers/YgoProAnalysisBasedOnDataFromYgoProServer.cs
@@ -155,7 +155,7 @@ namespace YGOProAnalyticsServer.EventHandlers
                 }
 
                 var numberOfDuplicatesWithListOfDecklists = _archetypeAndDecklistAnalyzer.
-                    RemoveDuplicateDecklistsFromListOfDecklists(decklist, allDecksFromOneDay);
+                    RemoveDuplicateDecklistsFromListOfDecklists(decklist, allDecksFromOneDay.OrderBy(x => x.WhenDecklistWasFirstPlayed));
                 decklistsWithoutDuplicates.Add(numberOfDuplicatesWithListOfDecklists.DecklistThatWasChecked);
                 var statistics = decklist.DecklistStatistics
                     .FirstOrDefault(x => x.DateWhenDeckWasUsed == decklist.WhenDecklistWasFirstPlayed);

--- a/YGOProAnalyticsServer/EventHandlers/YgoProAnalysisBasedOnDataFromYgoProServer.cs
+++ b/YGOProAnalyticsServer/EventHandlers/YgoProAnalysisBasedOnDataFromYgoProServer.cs
@@ -39,11 +39,11 @@ namespace YGOProAnalyticsServer.EventHandlers
             var duelLogsFromAllDates = notification.ConvertedDuelLogs;
             var decklistsAsStringsWithFilenames = notification.UnzippedDecklistsWithDecklistFileName;
 
-            foreach (var duelLogsFromOneDay in duelLogsFromAllDates)
+            foreach (var duelLogsPack in duelLogsFromAllDates)
             {
                 await _analyze(
-                    duelLogsFromOneDay,
-                    decklistsAsStringsWithFilenames.Where(x => x.Key == duelLogsFromOneDay.Key).First()
+                    duelLogsPack,
+                    decklistsAsStringsWithFilenames.Where(x => x.Key == duelLogsPack.Key).First()
                 );
             }
         }
@@ -135,7 +135,9 @@ namespace YGOProAnalyticsServer.EventHandlers
             }
         }
 
-        private List<Decklist> _analyzeDecklistsAndArchetypesAndRemoveDuplicates(List<Decklist> allDecksFromOneDay, bool decksWon)
+        private List<Decklist> _analyzeDecklistsAndArchetypesAndRemoveDuplicates(
+            List<Decklist> allDecksFromOneDay,
+            bool decksWon)
         {
             List<Decklist> decklistsWithoutDuplicates = new List<Decklist>();
             foreach (var decklist in allDecksFromOneDay)
@@ -155,7 +157,9 @@ namespace YGOProAnalyticsServer.EventHandlers
                 }
 
                 var numberOfDuplicatesWithListOfDecklists = _archetypeAndDecklistAnalyzer.
-                    RemoveDuplicateDecklistsFromListOfDecklists(decklist, allDecksFromOneDay.OrderBy(x => x.WhenDecklistWasFirstPlayed));
+                    RemoveDuplicateDecklistsFromListOfDecklists(
+                    decklist,
+                    allDecksFromOneDay.OrderBy(x => x.WhenDecklistWasFirstPlayed));
                 decklistsWithoutDuplicates.Add(numberOfDuplicatesWithListOfDecklists.DecklistThatWasChecked);
                 var statistics = decklist.DecklistStatistics
                     .FirstOrDefault(x => x.DateWhenDeckWasUsed == decklist.WhenDecklistWasFirstPlayed);
@@ -173,13 +177,18 @@ namespace YGOProAnalyticsServer.EventHandlers
                         IncrementNumberOfTimesWhenDeckWonByAmount(numberOfDuplicatesWithListOfDecklists.DuplicateCount);
                 }
 
-                var archetype = _archetypeAndDecklistAnalyzer.GetArchetypeOfTheDecklistWithStatistics(decklist, decklist.WhenDecklistWasFirstPlayed);
+                var archetype = _archetypeAndDecklistAnalyzer.GetArchetypeOfTheDecklistWithStatistics(
+                    decklist,
+                    decklist.WhenDecklistWasFirstPlayed);
                 var archetypeStatisticsFromDay = archetype.Statistics
                     .First(x => x.DateWhenArchetypeWasUsed == decklist.WhenDecklistWasFirstPlayed);
-                archetypeStatisticsFromDay.IncrementNumberOfDecksWhereWasUsedByAmount(numberOfDuplicatesWithListOfDecklists.DuplicateCount);
+
+                archetypeStatisticsFromDay.IncrementNumberOfDecksWhereWasUsedByAmount(
+                    numberOfDuplicatesWithListOfDecklists.DuplicateCount);
                 if (decksWon)
                 {
-                    archetypeStatisticsFromDay.IncrementNumberOfTimesWhenArchetypeWonByAmount(numberOfDuplicatesWithListOfDecklists.DuplicateCount);
+                    archetypeStatisticsFromDay.IncrementNumberOfTimesWhenArchetypeWonByAmount(
+                        numberOfDuplicatesWithListOfDecklists.DuplicateCount);
                 }
             }
 

--- a/YGOProAnalyticsServer/Services/Analyzers/ArchetypeAndDecklistAnalyzer.cs
+++ b/YGOProAnalyticsServer/Services/Analyzers/ArchetypeAndDecklistAnalyzer.cs
@@ -109,7 +109,7 @@ namespace YGOProAnalyticsServer.Services.Analyzers
         /// <returns>Amount of duplicates removed.</returns>
         public NumberOfDuplicatesWithListOfDecklists RemoveDuplicateDecklistsFromListOfDecklists(
             Decklist decklist, 
-            List<Decklist> listOfDecks)
+            IEnumerable<Decklist> listOfDecks)
         {
             int duplicateCount = 0;
             List<Decklist> listWithoutDuplicates = new List<Decklist>();

--- a/YGOProAnalyticsServer/Services/Analyzers/Interfaces/IArchetypeAndDecklistAnalyzer.cs
+++ b/YGOProAnalyticsServer/Services/Analyzers/Interfaces/IArchetypeAndDecklistAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using YGOProAnalyticsServer.DbModels;
 using YGOProAnalyticsServer.Models;
@@ -10,13 +11,17 @@ namespace YGOProAnalyticsServer.Services.Analyzers.Interfaces
     /// </summary>
     public interface IArchetypeAndDecklistAnalyzer
     {
-        NumberOfDuplicatesWithListOfDecklists RemoveDuplicateDecklistsFromListOfDecklists(Decklist decklist, IEnumerable<Decklist> listOfDecks);
+        NumberOfDuplicatesWithListOfDecklists RemoveDuplicateDecklistsFromListOfDecklists(
+            Decklist decklist,
+            IEnumerable<Decklist> listOfDecks);
 
         /// <summary>Sets the decklist archetype from archetype cards used in it.</summary>
         /// <param name="decklist">The decklist (Must contain non empty list of cards in deck).</param>
         /// <param name="dateWhenDecklistWasUsed">Date of when the decklist passed was used.</param>
         /// <returns>Decklist with archetype set</returns>
-        Archetype GetArchetypeOfTheDecklistWithStatistics(Decklist decklist, System.DateTime dateWhenDecklistWasUsed);
+        Archetype GetArchetypeOfTheDecklistWithStatistics(
+            Decklist decklist,
+            DateTime dateWhenDecklistWasUsed);
 
         /// <summary>
         /// Checks if decklists are duplicate.

--- a/YGOProAnalyticsServer/Services/Analyzers/Interfaces/IArchetypeAndDecklistAnalyzer.cs
+++ b/YGOProAnalyticsServer/Services/Analyzers/Interfaces/IArchetypeAndDecklistAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using YGOProAnalyticsServer.DbModels;
 using YGOProAnalyticsServer.Models;
 
@@ -9,7 +10,7 @@ namespace YGOProAnalyticsServer.Services.Analyzers.Interfaces
     /// </summary>
     public interface IArchetypeAndDecklistAnalyzer
     {
-        NumberOfDuplicatesWithListOfDecklists RemoveDuplicateDecklistsFromListOfDecklists(Decklist decklist, System.Collections.Generic.List<Decklist> listOfDecks);
+        NumberOfDuplicatesWithListOfDecklists RemoveDuplicateDecklistsFromListOfDecklists(Decklist decklist, IEnumerable<Decklist> listOfDecks);
 
         /// <summary>Sets the decklist archetype from archetype cards used in it.</summary>
         /// <param name="decklist">The decklist (Must contain non empty list of cards in deck).</param>


### PR DESCRIPTION
Thanks to this fix if a duel log contains more than one day in it, the decklists will be properly split between the dates and statistics will be made for each day.